### PR TITLE
Get rid unnecessary requests to ami because it exists on backend

### DIFF
--- a/src/client/containers/TaskTrainContainer/TaskTrainContainer.js
+++ b/src/client/containers/TaskTrainContainer/TaskTrainContainer.js
@@ -50,11 +50,9 @@ class TaskTrainContainer extends React.Component {
   }
 
   submitTask = () => {
-    const {id, taskId} = this.props.match.params;
+    const {taskId} = this.props.match.params;
     if (!this.state.solution) return;
     this.props.submitSolutionRequest({
-      userInfo: this.props.userInfo,
-      tournamentId: id,
       taskId: taskId,
       solutionCode: this.state.solution
     });
@@ -199,8 +197,7 @@ const mapStateToProps = (state) => {
     solutionResult: state.solution.result,
     solutionError: state.solution.error,
     solutionLoading: state.solution.isLoading,
-    solutionSubmitLoading: state.solution.isSubmitLoading,
-    userInfo: state.user.userInfo
+    solutionSubmitLoading: state.solution.isSubmitLoading
   };
 };
 

--- a/src/common/api/ami.js
+++ b/src/common/api/ami.js
@@ -1,7 +1,0 @@
-import axios from 'axios';
-
-import {AMI_ENDPOINT} from '../endpoints/index';
-
-export const postToAmi = (data) => {
-  return axios.post(AMI_ENDPOINT, data);
-};

--- a/src/common/endpoints/index.js
+++ b/src/common/endpoints/index.js
@@ -4,5 +4,4 @@ export const TASK_ENDPOINT = 'task';
 export const ME = 'me';
 export const USERS = 'user';
 export const PROFILE_ENDPOINT = 'profile';
-export const AMI_ENDPOINT = 'http://battle.frontspot.co/api-redirect/redirect/ami';
 export const SEC_ENDPOINT = 'sec';

--- a/src/common/sagas/solutionSaga.js
+++ b/src/common/sagas/solutionSaga.js
@@ -1,6 +1,4 @@
 import {call, put, takeEvery} from 'redux-saga/effects';
-import {getTournamentById} from '../api/tournaments';
-import {postToAmi} from '../api/ami';
 
 import {
   submitSolution,
@@ -21,21 +19,12 @@ import {
 
 function* sendSolution({payload}) {
   try {
-    const {solutionCode, taskId, tournamentId, userInfo} = payload;
+    const {solutionCode, taskId} = payload;
     if (!(solutionCode && taskId)) {
       return put(submitSolutionFailed('Empty solution'));
     }
     const submitResult = yield call(submitSolution, payload);
     yield put(submitSolutionSuccess(submitResult));
-    const tournament = yield call(getTournamentById, tournamentId);
-    if (tournament.solved === tournament.total) {
-      const dataToAmi = {
-        upsa: userInfo.upsa,
-        language: tournament.language,
-        tournament: tournament.id
-      };
-      yield call(postToAmi, dataToAmi);
-    }
   } catch (e) {
     yield put(submitSolutionFailed(e));
   }


### PR DESCRIPTION
This logic was as a workaround on FE side and should be implemented on backend side if it needed. Now it is redundant.